### PR TITLE
better kwarg and variadic usage

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -196,40 +196,45 @@ std::function<double( dialogue & )> armor_eval( char scope,
 std::function<double( dialogue & )> effect_intensity_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
-    bodypart_id bp = bodypart_str_id::NULL_ID();
+    diag_value bp_val( std::string{} );
     if( kwargs.count( "bodypart" ) != 0 ) {
-        bp = bodypart_str_id( kwargs.at( "bodypart" )->str() );
+        bp_val = *kwargs.at( "bodypart" );
     }
-    return[effect_id = params[0], bp, beta = is_beta( scope )]( dialogue const & d ) {
+    return[effect_id = params[0], bp_val, beta = is_beta( scope )]( dialogue const & d ) {
+        std::string const bp_str = bp_val.str( d );
+        bodypart_id const bp = bp_str.empty() ? bodypart_str_id::NULL_ID() : bodypart_id( bp_str );
         effect target = d.actor( beta )->get_effect( efftype_id( effect_id.str( d ) ), bp );
         return target.is_null() ? -1 : target.get_intensity();
     };
 }
 
 std::function<double( dialogue & )> hp_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
-    bodypart_id bp = bodypart_str_id::NULL_ID();
-    if( kwargs.count( "bodypart" ) != 0 ) {
-        bp = bodypart_str_id( kwargs.at( "bodypart" )->str() );
+    diag_value bp_val( std::string{} );
+    if( !params.empty() ) {
+        bp_val = params[0];
     }
-    return[bp, beta = is_beta( scope )]( dialogue const & d ) {
+    return[bp_val, beta = is_beta( scope )]( dialogue const & d ) {
+        std::string const bp_str = bp_val.str( d );
+        bodypart_id const bp = bp_str.empty() ? bodypart_str_id::NULL_ID() : bodypart_id( bp_str );
         return d.actor( beta )->get_cur_hp( bp );
     };
 }
 
 std::function<void( dialogue &, double )> hp_ass( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
-    bodypart_id bp = bodypart_str_id::NULL_ID();
-    if( kwargs.count( "bodypart" ) != 0 ) {
-        bp = bodypart_str_id( kwargs.at( "bodypart" )->str() );
+    diag_value bp_val( std::string{} );
+    if( !params.empty() ) {
+        bp_val = params[0];
     }
-    return [bp, beta = is_beta( scope )]( dialogue const & d, double val ) {
-        if( bp == bodypart_str_id::NULL_ID() ) {
+    return [bp_val, beta = is_beta( scope )]( dialogue const & d, double val ) {
+        std::string const bp_str = bp_val.str( d );
+        if( bp_str.empty() ) {
             d.actor( beta )->set_all_parts_hp_cur( val );
         } else {
-            d.actor( beta )->set_part_hp_cur( bp, val );
+            d.actor( beta )->set_part_hp_cur( bodypart_id( bp_str ), val );
         }
     };
 }

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -125,7 +125,7 @@ inline std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
     { "attack_speed", { "un", 0, attack_speed_eval } },
     { "effect_intensity", { "un", 1, effect_intensity_eval } },
     { "game_option", { "g", 1, option_eval } },
-    { "hp", { "un", 0, hp_eval } },
+    { "hp", { "un", -1, hp_eval } },
     { "hp_max", { "un", 1, hp_max_eval } },
     { "monsters_nearby", { "ung", -1, monsters_nearby_eval } },
     { "num_input", { "g", 2, num_input_eval } },
@@ -138,7 +138,7 @@ inline std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
 };
 
 inline std::map<std::string_view, dialogue_func_ass> const dialogue_assign_f{
-    { "hp", { "un", 0, hp_ass } },
+    { "hp", { "un", -1, hp_ass } },
     { "pain", { "un", 0, pain_ass } },
     { "skill", { "un", 1, skill_ass } },
     { "spell_exp", { "un", 1, spell_exp_ass}},


### PR DESCRIPTION
This is how I'd like it to work. I'm pretty particular about math code, especially now since there aren't many examples.

I've used this JSON to test

```JSON
  {
    "type": "effect_on_condition",
    "id": "test_hp_effect_intensity",
    "global": true,
    "effect": [
      { "math": [ "hp_noparam", "=", "u_hp()" ] },
      { "math": [ "hp_torso", "=", "u_hp('torso')" ] },
      { "math": [ "hp_var", "=", "u_hp(some_var)" ] },
      { "math": [ "effect_ins", "=", "u_effect_intensity('bleed', 'bodypart':some_var)" ] },
      {
        "u_message": "hp_noparam:<global_val:hp_noparam>\nhp_torso:<global_val:hp_torso>\nhp_var(<global_val:some_var>):<global_val:hp_var>\neffect_ins(<global_val:some_var>):<global_val:effect_ins>"
      }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "test_set_hp",
    "global": true,
    "effect": [ { "math": [ "u_hp()", "=", "400" ] }, { "math": [ "u_hp(some_var)", "=", "500" ] } ]
  },
```

This way it can work with variable parameters/kwargs and not just hardcoded strings.